### PR TITLE
Adding support for es6 files through babel compiler

### DIFF
--- a/lib/lasso-require-plugin.js
+++ b/lib/lasso-require-plugin.js
@@ -1,4 +1,5 @@
 var fs = require('fs');
+var babel = require('babel-core');
 var dependency_require = require('./dependency-require');
 var dependency_commonjs_def = require('./dependency-define');
 var dependency_commonjs_run = require('./dependency-run');
@@ -98,6 +99,54 @@ module.exports = exports = function plugin(lasso, config) {
                 lassoContext.getFileLastModified(path, callback);
             }
         });
+
+    // Extension for babel
+    function babelCompile(path, callback) {
+        'use strict';
+
+        // Override the default config if needed
+        var babelConfig = extend({
+            "optional": ['runtime']
+        }, config.babel);
+
+        babel.transformFile(path, babelConfig, function(err, result) {
+            if (err) {
+                return callback(err);
+            }
+            callback(null, result.code);
+        });
+    }
+
+    lasso.dependencies.registerJavaScriptType('es6', {
+        properties: {
+            'path': 'string'
+        },
+        init: function(lassoContext, callback) {
+            'use strict';
+            if (!this.path) {
+                return callback(new Error('"path" is required'));
+            }
+            this.path = this.resolvePath(this.path);
+            callback();
+        },
+        read: function(context, callback) {
+            babelCompile(this.path, callback);
+        },
+        getSourceFile: function() {
+            'use strict';
+            return this.path;
+        }
+    });
+
+    lasso.dependencies.registerRequireExtension('es6', {
+        read: function(path, lassoContext, callback) {
+            babelCompile(path, callback);
+        },
+
+        getLastModified: function(path, lassoContext, callback) {
+            lassoContext.getFileLastModified(path, callback);
+        }
+    });
 
     lasso.dependencies.registerRequireExtension('json', {
             object: true,

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "maintainers": "Patrick Steele-Idem <pnidem@gmail.com>",
     "dependencies": {
         "assert": "^1.1.2",
+        "babel-core": "^5.8.24",
         "buffer-browserify": "^0.2.2",
         "clone": "^0.1.19",
         "escodegen": "^1.6.0",


### PR DESCRIPTION
Please note that there are no test cases related to plugins in `lasso-require`. 