### PR TITLE
Improve Windows compatibility

### DIFF
--- a/lib/dependency-run.js
+++ b/lib/dependency-run.js
@@ -40,7 +40,7 @@ exports.create = function(config, lasso) {
 
         getUnbundledTarget: function() {
             var ext = nodePath.extname(this._file);
-            var fileNameNoExt = this._file;
+            var fileNameNoExt = nodePath.relative(config.rootDir, this._file);
             if (ext) {
                 fileNameNoExt = fileNameNoExt.substring(0, fileNameNoExt.length - ext.length);
             }


### PR DESCRIPTION
This function seems to be expected to return a relative path. Returning absolute path in Windows, puts lasso in endless loop, as path.join is invoked later with arguments like c:\some\folder and c:\some\folder\subfolder\filename.ext. This results in lasso trying to write to c:\some\folder\c:\some\folder\subfolder\filename.ext, which mysteriously is not yielding any error.