### PR TITLE
Adding support for babel paths to allow only whitelisted paths

### DIFF
--- a/lib/lasso-require-plugin.js
+++ b/lib/lasso-require-plugin.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var fs = require('fs');
 var babel;
 var dependency_require = require('./dependency-require');
@@ -56,12 +58,13 @@ module.exports = exports = function plugin(lasso, config) {
 
     /**
      * Lazily load the babel presets... it takes a long time!
+     * TODO for now it is just 'runtime' until we upgrade to v6
      */
     function getBabelConfig() {
         if (!babelConfigFinalized) {
             babelConfigFinalized = true;
-            if (!babelConfig.presets) {
-                babelConfig.presets = [require('babel-preset-es2015')];
+            if (!babelConfig.optional) {
+                babelConfig.optional = ['runtime'];
             }
         }
         return babelConfig;

--- a/lib/lasso-require-plugin.js
+++ b/lib/lasso-require-plugin.js
@@ -14,6 +14,8 @@ var dependency_commonjs_runtime = require('./dependency-commonjs-runtime');
 var Transforms = require('./util/Transforms');
 var resolve = require('./util/resolve');
 var extend = require('raptor-util').extend;
+var ignore = require('ignore');
+var pathModule = require('path');
 var resolveRequire = require('raptor-modules/resolver').resolveRequire;
 
 var requireRegExp = /^require\s+(.*)$/;
@@ -52,6 +54,17 @@ module.exports = exports = function plugin(lasso, config) {
 
     var babelExtensions = babelConfig.extensions || ['es6'];
     delete babelConfig.extensions;
+
+    var babelPaths = babelConfig.paths;
+    var babelIgnoreFilter = babelPaths && ignore().add(babelPaths
+        .map(function(path) { // add the root dir first
+            return pathModule.join(config.rootDir, path);
+        })
+        .map(function(path) { // remove the root dir and make it relative
+            return pathModule.relative(config.rootDir, path);
+        })
+    );
+    delete babelConfig.paths;
 
     var babelConfigFinalized = false;
 
@@ -158,6 +171,16 @@ module.exports = exports = function plugin(lasso, config) {
         }
     }
 
+    function isPathWhitelisted(path) {
+        if (!babelIgnoreFilter) {
+            // Return true if no path filter is present
+            return true;
+        }
+
+        var ignored = babelIgnoreFilter.filter(pathModule.relative(config.rootDir, path));
+        return !ignored.length; // Inverse the value as it is a ignore pattern
+    }
+
     var babelJavaScriptType = lasso.dependencies.createResourceTransformType(function(src, callback) {
         babelTransformCode(src, callback);
     });
@@ -167,7 +190,10 @@ module.exports = exports = function plugin(lasso, config) {
 
         lasso.dependencies.registerRequireExtension(babelExtension, {
             read: function(path, lassoContext, callback) {
-                babelTransformFile(path, callback);
+                if (isPathWhitelisted(path)) {
+                    return babelTransformFile(path, callback);
+                }
+                return fs.createReadStream(path, { encoding: 'utf8' });
             },
 
             getLastModified: function(path, lassoContext, callback) {

--- a/lib/lasso-require-plugin.js
+++ b/lib/lasso-require-plugin.js
@@ -1,5 +1,3 @@
-'use strict';
-
 var fs = require('fs');
 var babel;
 var dependency_require = require('./dependency-require');
@@ -59,13 +57,12 @@ module.exports = exports = function plugin(lasso, config) {
 
     /**
      * Lazily load the babel presets... it takes a long time!
-     * TODO for now it is just 'runtime' until we upgrade to v6
      */
     function getBabelConfig() {
         if (!babelConfigFinalized) {
             babelConfigFinalized = true;
-            if (!babelConfig.optional) {
-                babelConfig.optional = ['runtime'];
+            if (!babelConfig.presets) {
+                babelConfig.presets = [require('babel-preset-es2015')];
             }
         }
         return babelConfig;

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "maintainers": "Patrick Steele-Idem <pnidem@gmail.com>",
     "dependencies": {
         "assert": "^1.1.2",
-        "babel-core": "^6.0.20",
-        "babel-preset-es2015": "^6.1.2",
+        "babel-core": "^5.8.35",
+        "babel-runtime": "^5.8.35",
         "buffer-browserify": "^0.2.2",
         "clone": "^0.1.19",
         "escodegen": "^1.6.0",
@@ -62,5 +62,5 @@
         "path": "path-browserify",
         "stream": "stream-browserify"
     },
-    "version": "1.4.8"
+    "version": "1.4.9"
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "esprima": "^2.7.2",
     "estraverse": "^4.1.1",
     "events": "^1.0.2",
+    "ignore": "^3.1.1",
     "mkdirp": "^0.5.0",
     "path-browserify": "0.0.0",
     "process": "^0.6.0",


### PR DESCRIPTION
Please only review the latest [commit](https://github.com/lasso-js/lasso-require/commit/433a59393f9a1c806467efe39eb17b4f3412b00b)