### PR TITLE
Add url to defaultBuiltins

### DIFF
--- a/src/builtins.js
+++ b/src/builtins.js
@@ -17,6 +17,7 @@ var defaultBuiltins = {
     'process':        resolveBuiltin('process'),
     'stream':         resolveBuiltin('stream-browserify'),
     'util':           resolveBuiltin('util'),
+    'url':            resolveBuiltin('url'),
     'lasso-loader':  resolveBuiltin('lasso-loader'),
     'raptor-loader':  resolveBuiltin('lasso-loader'),
     'string_decoder': resolveBuiltin('string_decoder')


### PR DESCRIPTION
url is included in node js by default but not in lasso, this fix will allow lasso to work with dependencies that rely on the `url` module.