### PR TITLE
upgrade default babel preset

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "assert": "^1.1.2",
     "babel-core": "^6.7.6",
-    "babel-preset-es2015": "^6.1.2",
+    "babel-preset-env": "^1.6.0",
     "buffer": "^4.5.1",
     "clone": "^0.1.19",
     "escodegen": "^1.6.0",

--- a/src/build-plugin-config.js
+++ b/src/build-plugin-config.js
@@ -97,7 +97,7 @@ function buildPluginConfig(userConfig, defaultProjectRoot) {
             delete babelConfig.extensions;
 
             if (!babelConfig.presets) {
-                babelConfig.presets = [require('babel-preset-es2015')];
+                babelConfig.presets = [require('babel-preset-env')];
             }
         }
         return babelConfig;


### PR DESCRIPTION
Upgrade per this warning:
>warning babel-preset-es2015@6.24.1: 🙌  Thanks for using Babel: we recommend using babel-preset-env now: please read babeljs.io/env to update! 

It's a drop-in replacement, though I'd guess that the default lasso preset isn't used much anyway.
